### PR TITLE
Add acute diarrhea case definition from Brighton collaboration

### DIFF
--- a/definitions/v1/d/diarrhea_brightoncollaboration.json
+++ b/definitions/v1/d/diarrhea_brightoncollaboration.json
@@ -9,7 +9,7 @@
     "category": "suspected",
     "version": "1.0.0",
     "open_syndrome_version": "1.0.0",
-    "published_in": "https://opensyndrome.org/definitions/<replace-url>",
+    "published_in": "https://opensyndrome.org",
     "published_at": "2026-03-18T08:11:16Z",
     "published_by": ["Open Syndrome Initiative"],
     "location": "United States",


### PR DESCRIPTION
Added a standardized case definition for acute diarrhea as an Adverse Event Following Immunization (AEFI), including clinical criteria and details for consistent reporting.

Source: https://brightoncollaboration.org/diarrhea/
